### PR TITLE
Add support for Cassandra 3.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,13 +29,13 @@ repositories {
 }
 
 dependencies {
-	compile 'com.datastax.cassandra:cassandra-driver-core:2.1.7.1'
+	compile 'com.datastax.cassandra:cassandra-driver-core:3.0.1'
 	compile 'com.google.guava:guava:18.0'
 
 	testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
 	testCompile 'org.codehaus.groovy:groovy-all:2.4.4'
 	testRuntime 'io.netty:netty-all:4.1.0.Beta5'
-	testCompile 'org.cassandraunit:cassandra-unit:2.1.9.2'
+	testCompile 'org.cassandraunit:cassandra-unit:3.0.0.1'
 	testRuntime 'ch.qos.logback:logback-classic:1.1.3'
 }
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   java:
     version:
-      oraclejdk7
+      oraclejdk8
   environment:
     JAVA_OPTS: -Djava.awt.headless=true -server -Xmx1G
     GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1G -XX:+HeapDumpOnOutOfMemoryError"'

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -9,14 +9,14 @@ task sourceJar(type: Jar) {
 }
 
 if (isSnapshot) {
-	if (project.hasProperty('smartThingsArtifactoryUserName')) {
-		publishing {
-			publications {
-				main(MavenPublication) {
-					from components.java
-					artifact sourceJar
-				}
+	publishing {
+		publications {
+			main(MavenPublication) {
+				from components.java
+				artifact sourceJar
 			}
+		}
+		if (project.hasProperty('smartThingsArtifactoryUserName')) {
 			repositories {
 				maven {
 					credentials {

--- a/src/test/resources/test-cassandra.yaml
+++ b/src/test/resources/test-cassandra.yaml
@@ -584,3 +584,5 @@ encryption_options:
     # algorithm: SunX509
     # store_type: JKS
     # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA]
+
+hints_directory: /tmp/hints


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CASSANDRA-6717 mentions the changes introduced in Cassandra 3.x.
The connection determines the version of cassandra and runs an appropriate query based on that.

`publishing.gradle` has been tweaked to publish snapshots to local maven without needing `smartThingsArtifactoryUserName`