### PR TITLE
Do not throw exception when schema is not in agreement.

### DIFF
--- a/src/main/java/smartthings/cassandra/CassandraConnection.java
+++ b/src/main/java/smartthings/cassandra/CassandraConnection.java
@@ -5,7 +5,6 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import smartthings.migration.CassandraMigrationException;
 import smartthings.migration.MigrationParameters;
 
 import javax.net.ssl.KeyManagerFactory;
@@ -201,7 +200,6 @@ public class CassandraConnection implements AutoCloseable {
 						ResultSet resultSet = execute(trimmedStatement + ";");
 						if (!resultSet.getExecutionInfo().isSchemaInAgreement()) {
 							logger.error("Schema is not in agreement");
-							throw new CassandraMigrationException("Schema is not in agreement.");
 						}
 						runStatements.add(trimmedStatement);
 					}

--- a/src/test/groovy/smartthings/cassandra/CassandraConnectionSpec.groovy
+++ b/src/test/groovy/smartthings/cassandra/CassandraConnectionSpec.groovy
@@ -1,7 +1,9 @@
 package smartthings.cassandra
 
-import com.datastax.driver.core.*
-import smartthings.migration.CassandraMigrationException
+import com.datastax.driver.core.ExecutionInfo
+import com.datastax.driver.core.ResultSet
+import com.datastax.driver.core.Row
+import com.datastax.driver.core.Session
 import smartthings.migration.MigrationParameters
 import spock.lang.Specification
 
@@ -65,9 +67,7 @@ class CassandraConnectionSpec extends Specification {
 		1 * session.execute('CREATE TABLE;') >> createResultSet
 		1 * createResultSet.getExecutionInfo() >> createExecutionInfo
 		1 * createExecutionInfo.isSchemaInAgreement() >> false
-		1 * session.execute('DELETE FROM migrations WHERE name = ?', [migrationFileName])
 		0 * _
-		thrown(CassandraMigrationException)
 	}
 
 	def "Gets migration MD5"() {


### PR DESCRIPTION
 The exception caused scenarios where the migration row was removed even though Cassandra eventually achieves agreement.