### PR TITLE
Fix migration problem related to multiple ALTERs in CQL files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-	compile 'com.datastax.cassandra:cassandra-driver-core:3.1.0'
+	compile 'com.datastax.cassandra:cassandra-driver-core:3.2.0'
 	compile 'com.google.guava:guava:19.0'
 
 	testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'

--- a/src/main/java/smartthings/cassandra/CassandraConnection.java
+++ b/src/main/java/smartthings/cassandra/CassandraConnection.java
@@ -62,7 +62,10 @@ public class CassandraConnection implements AutoCloseable {
 	public void connect() throws Exception {
 		if (session == null) {
 			logger.debug("Connecting to Cassandra at " + host + ":" + port);
-			Cluster.Builder builder = Cluster.builder().addContactPoint(host).withPort(port);
+
+			QueryOptions queryOptions = new QueryOptions().setConsistencyLevel(ConsistencyLevel.ALL);
+
+			Cluster.Builder builder = Cluster.builder().addContactPoint(host).withPort(port).withMaxSchemaAgreementWaitSeconds(20).withQueryOptions(queryOptions);
 
 			if (all(truststorePath, truststorePassword, keystorePath, keystorePassword)) {
 				logger.debug("Using SSL for the connection");


### PR DESCRIPTION
- Changed the consistency level to all for migrations
- Increased the timer interval to ensure that schema is in agreement to 20 seconds