### PR TITLE
When reading migrations table, use Quorum consistency

### DIFF
--- a/src/main/java/smartthings/cassandra/CassandraConnection.java
+++ b/src/main/java/smartthings/cassandra/CassandraConnection.java
@@ -127,6 +127,10 @@ public class CassandraConnection implements AutoCloseable {
 		return session.execute(query);
 	}
 
+	public ResultSet execute(Statement query) {
+		return session.execute(query);
+	}
+
 	public void backfillMigrations() {
 		if (migrationsTableExists()) {
 			ResultSet result = execute("SELECT * FROM migrations");
@@ -251,7 +255,10 @@ public class CassandraConnection implements AutoCloseable {
 
 	public String getMigrationMd5(String fileName) {
 		File file = new File(fileName);
-		ResultSet result = execute("SELECT sha FROM migrations WHERE name=?", file.getName());
+		Statement query = new SimpleStatement("SELECT sha FROM migrations WHERE name=?", file.getName())
+				.setConsistencyLevel(ConsistencyLevel.QUORUM);
+
+		ResultSet result = execute(query);
 		if (result.isExhausted()) {
 			return null;
 		}

--- a/src/test/groovy/smartthings/cassandra/CassandraConnectionSpec.groovy
+++ b/src/test/groovy/smartthings/cassandra/CassandraConnectionSpec.groovy
@@ -79,7 +79,12 @@ class CassandraConnectionSpec extends Specification {
 		String result = cassandraConnection.getMigrationMd5('/tmp/add-column.cql')
 
 		then:
-		1 * session.execute('SELECT sha FROM migrations WHERE name=?', ['add-column.cql']) >> resultSet
+		1 * session.execute(_ as Statement) >> { SimpleStatement s ->
+			assert s.getQueryString() == 'SELECT sha FROM migrations WHERE name=?'
+			assert s.getObject(0) == 'add-column.cql'
+			assert s.getConsistencyLevel() == ConsistencyLevel.QUORUM
+			resultSet
+		}
 		1 * resultSet.isExhausted() >> false
 		1 * resultSet.one() >> row
 		1 * row.getString('sha') >> '1234567890'
@@ -95,7 +100,12 @@ class CassandraConnectionSpec extends Specification {
 		String result = cassandraConnection.getMigrationMd5('/tmp/add-column.cql')
 
 		then:
-		1 * session.execute('SELECT sha FROM migrations WHERE name=?', ['add-column.cql']) >> resultSet
+		1 * session.execute(_ as Statement) >> { SimpleStatement s ->
+			assert s.getQueryString() == 'SELECT sha FROM migrations WHERE name=?'
+			assert s.getObject(0) == 'add-column.cql'
+			assert s.getConsistencyLevel() == ConsistencyLevel.QUORUM
+			resultSet
+		}
 		1 * resultSet.isExhausted() >> true
 		0 * _
 		result == null


### PR DESCRIPTION
Use lower consitency (`QUORUM`) to read the migrations table, in order to figure
out if the current migration needs to be run or not. Other operations
that will actually insert data or change schemas, will still use `ALL`
consistency.

This will allow successfully running the migration code in situations
where NO schema changes are required and ALL the nodes are not
avaialble.