### PR TITLE
Add error log in removeMigration()

### DIFF
--- a/src/main/java/smartthings/cassandra/CassandraConnection.java
+++ b/src/main/java/smartthings/cassandra/CassandraConnection.java
@@ -235,7 +235,10 @@ public class CassandraConnection implements AutoCloseable {
 
 	private void removeMigration(String fileName) {
 		File file = new File(fileName);
-		execute("DELETE FROM migrations WHERE name = ?", file.getName());
+		ResultSet result = execute("DELETE FROM migrations WHERE name = ? IF EXISTS", file.getName());
+		if (!result.wasApplied()) {
+			logger.error("removing migration mark failed for " + fileName);
+		}
 	}
 
 	private boolean markMigration(String fileName, String sha, boolean override) {

--- a/src/test/groovy/smartthings/cassandra/CassandraConnectionSpec.groovy
+++ b/src/test/groovy/smartthings/cassandra/CassandraConnectionSpec.groovy
@@ -54,6 +54,7 @@ class CassandraConnectionSpec extends Specification {
 		String migrationFileName = 'make-a-table.cql'
 		ResultSet migrationsResultSet = Mock()
 		ResultSet createResultSet = Mock()
+		ResultSet removeResultSet = Mock()
 		ExecutionInfo createExecutionInfo = Mock()
 
 		when:
@@ -65,7 +66,8 @@ class CassandraConnectionSpec extends Specification {
 		1 * session.execute('CREATE TABLE;') >> createResultSet
 		1 * createResultSet.getExecutionInfo() >> createExecutionInfo
 		1 * createExecutionInfo.isSchemaInAgreement() >> false
-		1 * session.execute('DELETE FROM migrations WHERE name = ?', [migrationFileName])
+		1 * session.execute('DELETE FROM migrations WHERE name = ? IF EXISTS', [migrationFileName]) >> removeResultSet
+		1 * removeResultSet.wasApplied() >> true
 		0 * _
 		thrown(CassandraMigrationException)
 	}


### PR DESCRIPTION
Oberserved that occasionally removeMigration didn't succeed. This leaves failed
migration files still marked in the migration table. This patch adds additional
logging when this error happens.

@arunrao33 