### PR TITLE
Refactor migration leader selection logic

### DIFF
--- a/src/main/java/smartthings/cassandra/CassandraConnection.java
+++ b/src/main/java/smartthings/cassandra/CassandraConnection.java
@@ -39,15 +39,13 @@ public class CassandraConnection implements AutoCloseable {
 	private String password;
 
 	private String cassandraVersion;
+	private final String ownerName;
 
-	private static String UPSERT_LOCKTABLE = "UPDATE databasechangelock USING TTL 1000 SET locked = ?, lockedby = ? WHERE id = 1 IF locked = false";
-	private static String UPSERT_LOCKTABLE_WITH_NULL = "UPDATE databasechangelock USING TTL 1000 SET locked = ?, lockedby = ? WHERE id = 1 IF lockedby = null";
-	private static String UPSERT_RELEASE_LOCK = "UPDATE databasechangelock USING TTL 1000 SET locked = ?, lockedby = ? WHERE id = 1 if locked = true";
-	private static String INSERT_LOCK = "INSERT INTO databasechangelock(id, locked, lockedby) values(1, ?, ?) if not exists USING TTL 1000";
+	private CassandraLock lock;
 
+	public CassandraConnection(MigrationParameters parameters, String ownerName) {
+		this.ownerName = ownerName;
 
-
-	public CassandraConnection(MigrationParameters parameters) {
 		cipherSuites[0] = "TLS_RSA_WITH_AES_128_CBC_SHA";
 		cipherSuites[1] = "TLS_RSA_WITH_AES_256_CBC_SHA";
 
@@ -95,30 +93,16 @@ public class CassandraConnection implements AutoCloseable {
 
 		cassandraVersion = execute("select release_version from system.local where key = 'local'")
 				.one().getString(0);
+
+		lock = new CassandraLock(this);
 	}
-
-	public ResultSet checkMigrationRunning() {
-		ResultSet resultset = execute("SELECT * FROM databasechangelock WHERE id = 1");
-		return resultset;
-	}
-
-	public boolean isMigrationRunning() {
-
-		boolean isRunning = false;
-
-		ResultSet resultSet = execute("SELECT * FROM databasechangelock WHERE id = 1");
-
-		Row row = resultSet.one();
-		if(row != null){
-			isRunning = row.getBool("locked");
-		}
-
-		return isRunning;
-	}
-
 
 	@Override
 	public void close() {
+		if (lock != null) {
+			lock.unlock();
+		}
+
 		if (cluster != null) {
 			//We don't close the connection if we were given a session
 			cluster.close();
@@ -150,17 +134,25 @@ public class CassandraConnection implements AutoCloseable {
 		execute("use " + keyspace);
 	}
 
-	public ResultSet execute(String query) {
-		return session.execute(query);
+	public ResultSet execute(String query, Object... params) {
+		return session.execute(query, params);
 	}
 
-	public ResultSet execute(Statement query) {
-		return session.execute(query);
+
+	public ResultSet executeWithLock(String query, Object... params) {
+		if (lock.isMine()) {
+			lock.keepAlive();
+			ResultSet rs = execute(query, params);
+			lock.keepAlive();
+			return rs;
+		}
+
+		throw new CassandraLockException("attempt to execute without lock ownership");
 	}
 
 	public void backfillMigrations() {
 		if (tableExists("migrations")) {
-			ResultSet result = execute("SELECT * FROM migrations");
+			ResultSet result = executeWithLock("SELECT * FROM migrations");
 			List<Row> results = result.all();
 			int numMigrated = 0;
 			logger.info("Checking for migrations that need to be backfilled");
@@ -170,7 +162,7 @@ public class CassandraConnection implements AutoCloseable {
 
 				if (name.contains("/")) {
 					String truncatedName = name.substring(name.lastIndexOf("/") + 1);
-					ResultSet rs = execute("INSERT INTO migrations (name, sha) VALUES (?, ?) IF NOT EXISTS", truncatedName, sha);
+					ResultSet rs = executeWithLock("INSERT INTO migrations (name, sha) VALUES (?, ?) IF NOT EXISTS", truncatedName, sha);
 					if (rs.wasApplied()) {
 						numMigrated++;
 						logger.info("Backfilled migration. {} -> {}", name, truncatedName);
@@ -181,52 +173,19 @@ public class CassandraConnection implements AutoCloseable {
 		}
 	}
 
-	public ResultSet execute(String query, Object... params) {
-		return session.execute(query, params);
-	}
-
 	public void setupMigration() {
-
 		if (!session.getCluster().getMetadata().checkSchemaAgreement()) {
 			throw new CassandraMigrationException("Migration table setup precheck: schema not in agreement");
 		}
 		if (!tableExists("migrations")) {
 			logger.info("migrations table not found creating.");
-			ResultSet rs = execute("CREATE TABLE IF NOT EXISTS migrations " +
+			ResultSet rs = executeWithLock("CREATE TABLE IF NOT EXISTS migrations " +
 					"(name text, sha text," +
 					"PRIMARY KEY (name));");
 			if (!rs.getExecutionInfo().isSchemaInAgreement()) {
 				throw new CassandraMigrationException("Migration table creation postcheck: schema not in agreement");
 			}
 		}
-		if (!tableExists("databasechangelock")) {
-			logger.info("lock table not found creating.");
-			ResultSet rs = execute("CREATE TABLE IF NOT EXISTS databasechangelock " +
-					"(id int, locked boolean, lockedby text, " +
-					"PRIMARY KEY (id));");
-			if (!rs.getExecutionInfo().isSchemaInAgreement()) {
-				throw new CassandraMigrationException("databasechangelock table creation postcheck: schema not in agreement");
-			}
-
-			//populate the entry
-			//execute(INSERT_LOCK);
-		}
-	}
-
-	public ResultSet insertLock(Object ... params){
-		return execute(INSERT_LOCK, params);
-	}
-
-	public ResultSet upsertLockTable(Object... params) {
-		return execute(UPSERT_LOCKTABLE, params);
-	}
-
-	public ResultSet upsertLockTableWithNull(Object... params) {
-		return execute(UPSERT_LOCKTABLE_WITH_NULL, params);
-	}
-
-	public void releaseLockTable(Object... params) {
-		execute(UPSERT_RELEASE_LOCK, params);
 	}
 
 	public boolean tableExists(String tableName) {
@@ -265,7 +224,7 @@ public class CassandraConnection implements AutoCloseable {
 				for (String statement : statements) {
 					String trimmedStatement = statement.trim();
 					if (!trimmedStatement.equals("")) {
-						ResultSet resultSet = execute(trimmedStatement + ";");
+						ResultSet resultSet = executeWithLock(trimmedStatement + ";");
 						// may need to up Cluster.Builder.withMaxSchemaAgreementWaitSeconds
 						if (!resultSet.getExecutionInfo().isSchemaInAgreement()) {
 							logger.error("Schema is not in agreement");
@@ -296,7 +255,7 @@ public class CassandraConnection implements AutoCloseable {
 
 	private void removeMigration(String fileName) {
 		File file = new File(fileName);
-		ResultSet result = execute("DELETE FROM migrations WHERE name = ? IF EXISTS", file.getName());
+		ResultSet result = executeWithLock("DELETE FROM migrations WHERE name = ? IF EXISTS", file.getName());
 		if (!result.wasApplied()) {
 			logger.error("removing migration mark failed for " + fileName);
 		}
@@ -308,7 +267,7 @@ public class CassandraConnection implements AutoCloseable {
 
 		//We use the light weight transaction to make sure another process hasn't started the work, but only if we aren't overriding
 		String ifClause = override ? "" : "IF NOT EXISTS";
-		ResultSet result = execute("INSERT INTO migrations (name, sha) VALUES (?, ?) " + ifClause + ";", file.getName(), sha);
+		ResultSet result = executeWithLock("INSERT INTO migrations (name, sha) VALUES (?, ?) " + ifClause + ";", file.getName(), sha);
 
 		return override || result.wasApplied();
 	}
@@ -316,11 +275,22 @@ public class CassandraConnection implements AutoCloseable {
 	public boolean markMigration(String fileName, String sha) {
 		return markMigration(fileName, sha, false);
 	}
+
+	public void acquireLock() throws InterruptedException {
+		while(!lock.tryLock()) {
+			logger.info("Unable to acquire lock owned by %s. Sleeping...", lock.getOwner());
+			Thread.sleep(1000);
+		}
+		logger.info("Lock acquired!");
+	}
+
+	public void keepLockAlive() {
+		lock.keepAlive();
+	}
+
 	public String getMigrationMd5(String fileName) {
 		File file = new File(fileName);
-		Statement query = new SimpleStatement("SELECT sha FROM migrations WHERE name=?", file.getName()).setConsistencyLevel(ConsistencyLevel.QUORUM);
-
-		ResultSet result = execute(query);
+		ResultSet result = executeWithLock("SELECT sha FROM migrations WHERE name=?", file.getName());
 		if (result.isExhausted()) {
 			return null;
 		}
@@ -402,5 +372,9 @@ public class CassandraConnection implements AutoCloseable {
 
 	public void setKeystorePassword(String keystorePassword) {
 		this.keystorePassword = keystorePassword;
+	}
+
+	public String getOwnerName() {
+		return ownerName;
 	}
 }

--- a/src/main/java/smartthings/cassandra/CassandraLock.java
+++ b/src/main/java/smartthings/cassandra/CassandraLock.java
@@ -1,0 +1,123 @@
+package smartthings.cassandra;
+
+import com.datastax.driver.core.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import smartthings.migration.CassandraMigrationException;
+
+public class CassandraLock implements AutoCloseable {
+	private static final Logger logger = LoggerFactory.getLogger(CassandraLock.class);
+
+	private static final int lockId = 1;
+
+	private final int ttl;
+	private final CassandraConnection cassandraConnection;
+	private final String owner;
+	private final Session session;
+	private final PreparedStatement insertLock;
+	private final PreparedStatement deleteLock;
+	private final PreparedStatement selectLock;
+	private final PreparedStatement updateLock;
+
+	public CassandraLock(CassandraConnection cassandraConnection) {
+		this(cassandraConnection, 60);
+	}
+
+	public CassandraLock(CassandraConnection cassandraConnection, int ttl) {
+		this.ttl = ttl;
+		this.cassandraConnection = cassandraConnection;
+		this.session = cassandraConnection.getSession();
+		this.owner = cassandraConnection.getOwnerName();
+
+		setupTables();
+
+		insertLock = session.prepare("INSERT INTO databasechangelock(id, lockedby) VALUES (:lockId, :owner) IF NOT EXISTS USING TTL :ttl");
+		insertLock.setConsistencyLevel(ConsistencyLevel.QUORUM);
+
+		deleteLock = session.prepare("DELETE FROM databasechangelock WHERE id = :lockId IF lockedby = :owner");
+		deleteLock.setConsistencyLevel(ConsistencyLevel.QUORUM);
+
+		selectLock = session.prepare("SELECT lockedby, TTL(lockedby) AS ttl FROM databasechangelock WHERE id = :lockId");
+		selectLock.setConsistencyLevel(ConsistencyLevel.SERIAL);
+
+		updateLock = session.prepare("UPDATE databasechangelock USING TTL :ttl SET lockedby = :owner WHERE id = :lockId IF lockedby = :owner");
+		deleteLock.setConsistencyLevel(ConsistencyLevel.QUORUM);
+	}
+
+	public boolean tryLock() {
+		ResultSet rs = session.execute(insertLock.bind().setInt("lockId", lockId)
+				.setInt("ttl", ttl).setString("owner", owner));
+		if (rs.wasApplied()) {
+			return true;
+		} else {
+			Row row = rs.one();
+			return owner.equals(row.getString("lockedby"));
+		}
+	}
+
+	public void unlock() {
+		// Only try to release lock if its mine
+		if (isMine()) {
+			ResultSet rs = session.execute(deleteLock.bind().setInt("lockId", lockId).setString("owner", owner));
+			if (!rs.wasApplied()) {
+				// if ownership was lost, should be fine, since we are relinquishing ownership
+				if (isMine()) {
+					throw new CassandraLockException("unable to release lock");
+				}
+			}
+		}
+	}
+
+	public void keepAlive() {
+		ResultSet rs = session.execute(updateLock.bind().setInt("lockId", lockId)
+				.setInt("ttl", ttl).setString("owner", owner));
+		if (!rs.wasApplied()) {
+			throw new CassandraLockException("unable to keep alive lock");
+		}
+	}
+
+	public String getOwner() {
+		Row row = session.execute(selectLock.bind().setInt("lockId", lockId)).one();
+		if (row != null) {
+			return row.getString("lockedby");
+		}
+
+		return null;
+	}
+
+	public int getTtl() {
+		Row row = session.execute(selectLock.bind().setInt("lockId", lockId)).one();
+		if (row != null) {
+			return row.getInt("ttl");
+		}
+
+		return 0;
+	}
+
+	public boolean isLocked() {
+		return getOwner() != null;
+	}
+
+	public boolean isMine() {
+		return owner.equals(getOwner());
+	}
+
+	@Override
+	public void close() {
+		if (isMine()) {
+			unlock();
+		}
+	}
+
+	private void setupTables() {
+		if (!cassandraConnection.tableExists("databasechangelock")) {
+			logger.info("lock table not found creating.");
+			ResultSet rs = session.execute("CREATE TABLE IF NOT EXISTS databasechangelock " +
+					"(id int, lockedby text, " +
+					"PRIMARY KEY (id));");
+			if (!rs.getExecutionInfo().isSchemaInAgreement()) {
+				throw new CassandraMigrationException("databasechangelock table creation postcheck: schema not in agreement");
+			}
+		}
+	}
+}

--- a/src/main/java/smartthings/cassandra/CassandraLockException.java
+++ b/src/main/java/smartthings/cassandra/CassandraLockException.java
@@ -1,0 +1,8 @@
+package smartthings.cassandra;
+
+public class CassandraLockException extends RuntimeException {
+
+	public CassandraLockException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/smartthings/migration/ExecuteExternallyHandler.java
+++ b/src/main/java/smartthings/migration/ExecuteExternallyHandler.java
@@ -31,7 +31,10 @@ public class ExecuteExternallyHandler implements Handler {
 			System.out.println(command);
 			try {
 				Process process = Runtime.getRuntime().exec(command);
-				process.waitFor();
+				while (process.isAlive()) {
+					connection.keepLockAlive();
+					Thread.sleep(1000);
+				}
 				if (process.exitValue() == 0) {
 					connection.markMigration(fileName, md5);
 				}

--- a/src/test/groovy/smartthings/cassandra/CassandraLockSpec.groovy
+++ b/src/test/groovy/smartthings/cassandra/CassandraLockSpec.groovy
@@ -1,0 +1,190 @@
+package smartthings.cassandra
+
+import org.cassandraunit.CassandraCQLUnit
+import org.cassandraunit.dataset.CQLDataSet
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet
+import smartthings.migration.MigrationParameters
+import spock.lang.Specification
+
+class CassandraLockSpec extends Specification {
+	static final String owner = 'its-me'
+	static final keySpace = 'test_lock'
+	static final MigrationParameters params = new MigrationParameters.Builder()
+			.setHost('localhost')
+			.setPort(9142)
+			.setKeyspace(keySpace)
+			.setMigrationsLogFile('/cassandra/success.changelog')
+			.build()
+
+	CassandraCQLUnit cassandraCQLUnit
+
+	def setup() {
+		CQLDataSet dataSet = new ClassPathCQLDataSet('test-baseline.cql', keySpace)
+		cassandraCQLUnit = new CassandraCQLUnit(dataSet, 'test-cassandra.yaml', 30000L, 3000)
+		cassandraCQLUnit.before()
+	}
+
+	def cleanup() {
+		cassandraCQLUnit.after()
+	}
+
+	def 'single threaded lock works as expected'() {
+		given: 'connection'
+		CassandraConnection connection = new CassandraConnection(params, owner)
+		connection.connect()
+
+		and: 'lock'
+		CassandraLock lock = new CassandraLock(connection)
+
+		expect: 'initially is unlocked'
+		!lock.locked
+
+		and: 'returns true when acquiring lock'
+		lock.tryLock()
+
+		and: 'lock is locked'
+		lock.locked
+
+		when:
+		lock.keepAlive()
+
+		then:
+		noExceptionThrown()
+
+		expect:
+		lock.owner == owner
+
+		and: 'the lock was acquired by me'
+		lock.mine
+
+		when:
+		lock.unlock()
+
+		then: 'lock is not locked'
+		!lock.locked
+		!lock.mine
+		!lock.owner
+
+		when:
+		lock.unlock()
+
+		then:
+		noExceptionThrown()
+
+		when:
+		lock.keepAlive()
+
+		then:
+		thrown(CassandraLockException)
+	}
+
+	def 'lock is relinquished when TTL is expired'() {
+		given:
+		CassandraConnection connection = new CassandraConnection(params, owner)
+		connection.connect()
+
+		and: 'lock with ttl of 5 seconds'
+		CassandraLock lock = new CassandraLock(connection, 5)
+
+		expect:
+		lock.tryLock()
+
+		and:
+		lock.mine
+
+		when:
+		Thread.sleep(6000)
+
+		then:
+		!lock.mine
+		!lock.locked
+	}
+
+	def 'keep alive extends lock TTL'() {
+		given:
+		CassandraConnection connection = new CassandraConnection(params, owner)
+		connection.connect()
+
+		and: 'lock with ttl of 5 seconds'
+		CassandraLock lock = new CassandraLock(connection, 10)
+
+		when:
+		lock.tryLock()
+
+		then:
+		lock.mine
+		lock.ttl > 0
+
+		when:
+		Thread.sleep(5000)
+		int lockTtl = lock.ttl
+
+		then:
+		lockTtl > 0
+
+		when:
+		lock.keepAlive()
+
+		then:
+		lock.ttl >= lockTtl
+	}
+
+	def 'only one owner can acquire a lock'() {
+		given: 'owner named 1'
+		String owner1 = '1'
+		CassandraConnection connection1 = new CassandraConnection(params, owner1)
+		connection1.connect()
+		CassandraLock lock1 = new CassandraLock(connection1, 5)
+
+		and: 'owner named 2'
+		String owner2 = '2'
+		CassandraConnection connection2 = new CassandraConnection(params, owner2)
+		connection2.connect()
+		CassandraLock lock2 = new CassandraLock(connection2, 5)
+
+		expect: 'no one owns the lock'
+		!lock1.mine
+		!lock1.locked
+		!lock2.locked
+		!lock2.mine
+
+		and: 'only 1 acquired lock'
+		lock1.tryLock()
+		!lock2.tryLock()
+
+		and: '1 reports lock status and ownership'
+		lock1.locked
+		lock1.mine
+		lock1.owner == owner1
+
+		and: '2 reports lock status and ownership'
+		lock2.locked
+		!lock2.mine
+		lock2.owner == owner1
+
+		when: '1 relinquishes lock'
+		lock1.unlock()
+
+		then: '2 can acquire lock'
+		lock2.tryLock()
+		!lock1.tryLock()
+
+		expect:
+		lock1.locked
+		!lock1.mine
+		lock1.owner == owner2
+
+		and:
+		lock2.locked
+		lock2.mine
+		lock2.owner == owner2
+
+		when: 'lock ttl expires'
+		Thread.sleep(5000)
+
+		then:
+		!lock1.locked
+		!lock2.locked
+		lock1.tryLock()
+	}
+}


### PR DESCRIPTION
* Cleanup and reorganize code for clarity. Move lock operations into
  it's own class.
* Improve locking semantics, when releasing lock remove row from table
  instead of updating value.
* Reduce required TTL to a sensible value and use keep alive mechanism
  to keep ownership of the lock.
* Improve testing of locking code.