### PR TITLE
Remove metrics-jmx dependency

### DIFF
--- a/src/main/java/smartthings/cassandra/CassandraConnection.java
+++ b/src/main/java/smartthings/cassandra/CassandraConnection.java
@@ -70,7 +70,12 @@ public class CassandraConnection implements AutoCloseable {
 
 			QueryOptions queryOptions = new QueryOptions().setConsistencyLevel(ConsistencyLevel.QUORUM);
 
-			Cluster.Builder builder = Cluster.builder().addContactPoint(host).withPort(port).withMaxSchemaAgreementWaitSeconds(20).withQueryOptions(queryOptions);
+			Cluster.Builder builder = Cluster.builder()
+				.withoutJMXReporting()
+				.addContactPoint(host)
+				.withPort(port)
+				.withMaxSchemaAgreementWaitSeconds(20)
+				.withQueryOptions(queryOptions);
 
 			if (all(truststorePath, truststorePassword, keystorePath, keystorePassword)) {
 				logger.debug("Using SSL for the connection");


### PR DESCRIPTION
We were seeing the following:

```
java.lang.NoClassDefFoundError: com/codahale/metrics/JmxReporter
	at com.datastax.driver.core.Metrics.<init>(Metrics.java:146)
	at com.datastax.driver.core.Cluster$Manager.init(Cluster.java:1501)
	at com.datastax.driver.core.Cluster.init(Cluster.java:208)
	at com.datastax.driver.core.Cluster.connectAsync(Cluster.java:376)
	at com.datastax.driver.core.Cluster.connectAsync(Cluster.java:355)
	at com.datastax.driver.core.Cluster.connect(Cluster.java:305)
	at smartthings.cassandra.CassandraConnection.connect(CassandraConnection.java:89)
	at smartthings.migration.MigrationRunner.run(MigrationRunner.java:53)
```
After upgrading to Metrix 4.x

Per:
https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/#metrics-4-compatibility

This is adding a call to `.withoutJMXReporting()` to remove the
dependency on `com.codahale.metrics.JmxReporter`

I didn't want to change the project dependencies so there is no test to reproduce.